### PR TITLE
fix #19: Sort CSV field names prior to export

### DIFF
--- a/things_cli/cli.py
+++ b/things_cli/cli.py
@@ -139,6 +139,7 @@ class ThingsCLI:  # pylint: disable=too-many-instance-attributes
             fieldnames.remove("items")
         if "checklist" in fieldnames:
             fieldnames.remove("checklist")
+        fieldnames.sort()  # Because task content affects the order that fields are discovered above
 
         output = StringIO()
         writer = csv.DictWriter(


### PR DESCRIPTION
This is to achieve a stable column order for CSV exports, as the order in which CSV fields are discovered is influenced by the order of the tasks, as tasks can have differing sets of fields.